### PR TITLE
Allow the client to return a special value from thread_pre_create,

### DIFF
--- a/src/monitor.h
+++ b/src/monitor.h
@@ -44,6 +44,8 @@ typedef int monitor_sighandler_t(int, siginfo_t *, void *);
 
 enum { MONITOR_EXIT_NORMAL = 1, MONITOR_EXIT_SIGNAL, MONITOR_EXIT_EXEC };
 
+#define MONITOR_IGNORE_NEW_THREAD  ((void *) -1)
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
MONITOR_IGNORE_NEW_THREAD, that tells monitor not to track this new
thread (and descendant threads).

----------

@blue42u @jmellorcrummey 
Try this.  If monitor_thread_pre_create() returns MONITOR_IGNORE_NEW_THREAD,
then monitor will not track the new thread and you won't get an init/fini
callback and not a post_create callback.

For now, just build monitor separately.  You'll want configure args:

```
  --disable-dlfcn
  --enable-client-signals='SIGBUS, SIGSEGV, SIGPROF, 36, 37, 38'
```

If this works, we can merge it into master.  I'm working on some other
things for monitor, so I'm going to hold off making a monitor release
until I finish those things.