### PR TITLE
Search all loaded objects on dlsym(RTLD_NEXT) fail

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,7 +39,7 @@
 # library and then add that to the real library.  See Section 27.8,
 # "Per-Object Flags Emulation" of automake docs.  Blech.
 
-MONITOR_MAIN_FILES = callback.c mpi.c utils.c
+MONITOR_MAIN_FILES = callback.c mpi.c utils.c common.c
 MONITOR_THREAD_FILES =
 
 MONITOR_FENCE_FILES = main.c

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -175,7 +175,8 @@ libmonitor_wrap_a_AR = $(AR) $(ARFLAGS)
 @MONITOR_TEST_LINK_STATIC_TRUE@	$(am__append_16)
 am__objects_4 = libmonitor_wrap_a-callback.$(OBJEXT) \
 	libmonitor_wrap_a-mpi.$(OBJEXT) \
-	libmonitor_wrap_a-utils.$(OBJEXT)
+	libmonitor_wrap_a-utils.$(OBJEXT) \
+	libmonitor_wrap_a-common.$(OBJEXT)
 @MONITOR_TEST_LINK_STATIC_TRUE@@MONITOR_TEST_USE_DLOPEN_TRUE@am__objects_5 = libmonitor_wrap_a-dlopen.$(OBJEXT)
 @MONITOR_TEST_LINK_STATIC_TRUE@@MONITOR_TEST_USE_FORK_TRUE@am__objects_6 = libmonitor_wrap_a-fork.$(OBJEXT)
 am__objects_7 =
@@ -226,7 +227,7 @@ libfence_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 @MONITOR_TEST_LINK_PRELOAD_TRUE@libmonitor_la_DEPENDENCIES =  \
 @MONITOR_TEST_LINK_PRELOAD_TRUE@	libfence.la
 am__objects_15 = libmonitor_la-callback.lo libmonitor_la-mpi.lo \
-	libmonitor_la-utils.lo
+	libmonitor_la-utils.lo libmonitor_la-common.lo
 @MONITOR_TEST_LINK_PRELOAD_TRUE@@MONITOR_TEST_USE_DLOPEN_TRUE@am__objects_16 = libmonitor_la-dlopen.lo
 @MONITOR_TEST_LINK_PRELOAD_TRUE@@MONITOR_TEST_USE_FORK_TRUE@am__objects_17 = libmonitor_la-fork.lo
 @MONITOR_TEST_LINK_PRELOAD_TRUE@@MONITOR_TEST_USE_PTHREADS_TRUE@am__objects_18 = $(am__objects_7)
@@ -441,7 +442,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 wrap_list = @wrap_list@
-MONITOR_MAIN_FILES = callback.c mpi.c utils.c
+MONITOR_MAIN_FILES = callback.c mpi.c utils.c common.c
 MONITOR_THREAD_FILES = 
 MONITOR_FENCE_FILES = main.c
 MONITOR_THREAD_FENCE_FILES = pthread.c
@@ -683,6 +684,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libfence_wrap_a-main.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libfence_wrap_a-pthread.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_la-callback.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_la-common.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_la-dlopen.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_la-fork.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_la-mpi.Plo@am__quote@
@@ -706,6 +708,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_la-signal.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_la-utils.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_wrap_a-callback.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_wrap_a-common.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_wrap_a-dlopen.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_wrap_a-fork.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libmonitor_wrap_a-mpi.Po@am__quote@
@@ -818,6 +821,20 @@ libmonitor_wrap_a-utils.obj: utils.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='utils.c' object='libmonitor_wrap_a-utils.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_wrap_a_CPPFLAGS) $(CPPFLAGS) $(libmonitor_wrap_a_CFLAGS) $(CFLAGS) -c -o libmonitor_wrap_a-utils.obj `if test -f 'utils.c'; then $(CYGPATH_W) 'utils.c'; else $(CYGPATH_W) '$(srcdir)/utils.c'; fi`
+
+libmonitor_wrap_a-common.o: common.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_wrap_a_CPPFLAGS) $(CPPFLAGS) $(libmonitor_wrap_a_CFLAGS) $(CFLAGS) -MT libmonitor_wrap_a-common.o -MD -MP -MF $(DEPDIR)/libmonitor_wrap_a-common.Tpo -c -o libmonitor_wrap_a-common.o `test -f 'common.c' || echo '$(srcdir)/'`common.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libmonitor_wrap_a-common.Tpo $(DEPDIR)/libmonitor_wrap_a-common.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='common.c' object='libmonitor_wrap_a-common.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_wrap_a_CPPFLAGS) $(CPPFLAGS) $(libmonitor_wrap_a_CFLAGS) $(CFLAGS) -c -o libmonitor_wrap_a-common.o `test -f 'common.c' || echo '$(srcdir)/'`common.c
+
+libmonitor_wrap_a-common.obj: common.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_wrap_a_CPPFLAGS) $(CPPFLAGS) $(libmonitor_wrap_a_CFLAGS) $(CFLAGS) -MT libmonitor_wrap_a-common.obj -MD -MP -MF $(DEPDIR)/libmonitor_wrap_a-common.Tpo -c -o libmonitor_wrap_a-common.obj `if test -f 'common.c'; then $(CYGPATH_W) 'common.c'; else $(CYGPATH_W) '$(srcdir)/common.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libmonitor_wrap_a-common.Tpo $(DEPDIR)/libmonitor_wrap_a-common.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='common.c' object='libmonitor_wrap_a-common.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_wrap_a_CPPFLAGS) $(CPPFLAGS) $(libmonitor_wrap_a_CFLAGS) $(CFLAGS) -c -o libmonitor_wrap_a-common.obj `if test -f 'common.c'; then $(CYGPATH_W) 'common.c'; else $(CYGPATH_W) '$(srcdir)/common.c'; fi`
 
 libmonitor_wrap_a-dlopen.o: dlopen.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_wrap_a_CPPFLAGS) $(CPPFLAGS) $(libmonitor_wrap_a_CFLAGS) $(CFLAGS) -MT libmonitor_wrap_a-dlopen.o -MD -MP -MF $(DEPDIR)/libmonitor_wrap_a-dlopen.Tpo -c -o libmonitor_wrap_a-dlopen.o `test -f 'dlopen.c' || echo '$(srcdir)/'`dlopen.c
@@ -1119,6 +1136,13 @@ libmonitor_la-utils.lo: utils.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='utils.c' object='libmonitor_la-utils.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_la_CPPFLAGS) $(CPPFLAGS) $(libmonitor_la_CFLAGS) $(CFLAGS) -c -o libmonitor_la-utils.lo `test -f 'utils.c' || echo '$(srcdir)/'`utils.c
+
+libmonitor_la-common.lo: common.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_la_CPPFLAGS) $(CPPFLAGS) $(libmonitor_la_CFLAGS) $(CFLAGS) -MT libmonitor_la-common.lo -MD -MP -MF $(DEPDIR)/libmonitor_la-common.Tpo -c -o libmonitor_la-common.lo `test -f 'common.c' || echo '$(srcdir)/'`common.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libmonitor_la-common.Tpo $(DEPDIR)/libmonitor_la-common.Plo
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='common.c' object='libmonitor_la-common.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_la_CPPFLAGS) $(CPPFLAGS) $(libmonitor_la_CFLAGS) $(CFLAGS) -c -o libmonitor_la-common.lo `test -f 'common.c' || echo '$(srcdir)/'`common.c
 
 libmonitor_la-dlopen.lo: dlopen.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmonitor_la_CPPFLAGS) $(CPPFLAGS) $(libmonitor_la_CFLAGS) $(CFLAGS) -MT libmonitor_la-dlopen.lo -MD -MP -MF $(DEPDIR)/libmonitor_la-dlopen.Tpo -c -o libmonitor_la-dlopen.lo `test -f 'dlopen.c' || echo '$(srcdir)/'`dlopen.c

--- a/src/common.c
+++ b/src/common.c
@@ -1,0 +1,113 @@
+/*
+ *  Internal shared functions.
+ *
+ *  Copyright (c) 2007-2023, Rice University.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are
+ *  met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Rice University (RICE) nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  This software is provided by RICE and contributors "as is" and any
+ *  express or implied warranties, including, but not limited to, the
+ *  implied warranties of merchantability and fitness for a particular
+ *  purpose are disclaimed. In no event shall RICE or contributors be
+ *  liable for any direct, indirect, incidental, special, exemplary, or
+ *  consequential damages (including, but not limited to, procurement of
+ *  substitute goods or services; loss of use, data, or profits; or
+ *  business interruption) however caused and on any theory of liability,
+ *  whether in contract, strict liability, or tort (including negligence
+ *  or otherwise) arising in any way out of the use of this software, even
+ *  if advised of the possibility of such damage.
+ *
+ *  $Id$
+ */
+
+#define _GNU_SOURCE
+
+#include "common.h"
+#include "monitor.h"
+
+#include <dlfcn.h>
+#include <link.h>
+#include <stdbool.h>
+
+struct callback_data {
+    const char* symbol;
+    bool skip;
+    void *skip_until_base;
+    void *result;
+};
+static int phdr_callback(struct dl_phdr_info *info, size_t sz, void *data_v) {
+    struct callback_data *data = data_v;
+
+    // Decide whether to skip this object as being before libmonitor
+    if (data->skip) {
+        MONITOR_DEBUG("not scanning object: %s\n", info->dlpi_name);
+        if (data->skip_until_base == (void*)info->dlpi_addr) {
+            data->skip = false;
+        }
+        return 0;
+    }
+
+    // Call dlopen to stabilize a handle for our use
+    void *this = dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD | RTLD_LOCAL);
+    if (this == NULL) {
+        MONITOR_DEBUG("dlopen failed on object: %s\n", info->dlpi_name);
+        return 0;
+    }
+
+    // Poke it and see if we can find the symbol we want. Stop if we found it,
+    // otherwise continue the scan.
+    data->result = dlsym(this, data->symbol);
+    dlclose(this);
+    return data->result == NULL ? 0 : 1;
+}
+
+void *monitor_dlsym(const char *symbol) {
+    const char *err_str;
+    dlerror();
+    void *result = dlsym(RTLD_NEXT, symbol);
+    err_str = dlerror();
+    if (err_str != NULL) {
+        // Fallback: try to find the symbol by inspecting every object loaded
+        // after us. This is similar to but not identical to RTLD_NEXT, since we
+        // also inspect objects that were loaded with dlopen(RTLD_LOCAL).
+
+        struct callback_data cb_data = {
+            .symbol = symbol,
+            .skip = true,
+            .skip_until_base = NULL,
+            .result = NULL,
+        };
+
+        // Identify ourselves, using our base address
+        Dl_info dli;
+        if (dladdr(&monitor_dlsym, &dli) == 0) {
+            // This should never happen, but if it does error
+            MONITOR_ERROR1("dladdr1 failed to find libmonitor\n");
+        }
+        cb_data.skip_until_base = dli.dli_fbase;
+
+        // Use dl_iterate_phdr to scan through all the objects
+        int found = dl_iterate_phdr(phdr_callback, &cb_data);
+        if (found == 0 || cb_data.result == NULL) {
+            // We didn't find the required symbol, this is a hard error.
+            MONITOR_ERROR("dlsym(%s) failed: %s\n", symbol, err_str);
+        }
+        result = cb_data.result;
+    }
+    MONITOR_DEBUG("%s() = %p\n", symbol, result);
+    return result;
+}

--- a/src/common.h
+++ b/src/common.h
@@ -122,17 +122,11 @@
 #define MONITOR_ERROR1(fmt)      MONITOR_ERROR_ARGS(fmt, __func__)
 #define MONITOR_ERROR(fmt, ...)  MONITOR_ERROR_ARGS(fmt, __func__, __VA_ARGS__)
 
+void *monitor_dlsym(const char *symbol);
+
 #define MONITOR_REQUIRE_DLSYM(var, name)  do {		\
     if (var == NULL) {					\
-	const char *err_str;				\
-	dlerror();					\
-	var = dlsym(RTLD_NEXT, (name));			\
-	err_str = dlerror();				\
-	if (var == NULL) {				\
-	    MONITOR_ERROR("dlsym(%s) failed: %s\n",	\
-			 (name), err_str);		\
-	}						\
-	MONITOR_DEBUG("%s() = %p\n", (name), var);	\
+        var = monitor_dlsym(name);                      \
     }							\
 } while (0)
 


### PR DESCRIPTION
If a library is loaded with `dlopen(RTLD_LOCAL)`, the libmonitor symbols still override those provided by the loaded library, however libmonitor is unable to find an implementation via `dlsym(RTLD_NEXT)` since the object is not present in the global search list.

This commit adds a fallback when `dlsym(RTLD_NEXT)` fails, we now scan through every loaded object and `dlsym()` it to find the symbol we want. To prevent recursion with outer LD_PRELOAD wrappers, we start the search only after encountering libmonitor itself. In short, this fallback is similar to `dlsym(RTLD_NEXT)` but searches "deep" for the symbol, past the standard search list.

Required to fix https://gitlab.com/hpctoolkit/hpctoolkit/-/issues/744. CC @mwkrentel @jmellorcrummey 